### PR TITLE
Modified the architecture to retrieve all messages in a thread.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,11 @@
 * Created abstract functions to help us handle storage operations for user preferences.
 * Added placeholder function that allows us to add our email analysis.
 * Added placeholder function to alert the user of suspected phishing emails.
+
+## 10/20/2017 - Mike
+* Converted the code to retrieve the email thread since it was only retrieving the original email message.
+* Removes sent emails from the thread since we are only scanning incoming email messages.
+* Tweaked the email body parser response if only HTML is available.
+* Limits the data that's returned per email to what is necessary to filter out properties that are unnecessary.
+	* Added from, to, and subject properties - pulled from the headers
+* Changed the extension name and description from Mike's PoC to "INSuRE - NEU Anti-Phishing Extension" 

--- a/js/gmail.fetch.js
+++ b/js/gmail.fetch.js
@@ -5,28 +5,64 @@
 
 /**
  * Retrieves a single email by id
- * @param emailId {String} email message id
+ * @param threadId {String} message thread id
  * @return {promise}
  */
-this.retrieveSingleEmail = function (emailId) {
-    return gapi.client.gmail.users.messages.get({
+this.retrieveEmailThread = function (threadId) {
+    return gapi.client.gmail.users.threads.get({
         userId: 'me',
-        id: emailId
+        id: threadId
     })
-        .then(preProcessEmails)
+        .then(pluckEmailsFromThread)
+        .then(filterOutSentEmails)
+        .then(processEmails);
 };
 
 /**
- * Pre-processes email messages:
- *      - adds the unread, emailDate, and emailMessage properties to the email
- * @param email {object} email message
+ * Simply returns the messages from the thread object that is returned
+ * @param thread
+ * @returns {*|Object}
+ */
+function pluckEmailsFromThread (thread) {
+    return thread && thread.result && thread.result.messages;
+}
+
+/**
+ * Returns a list of emails that were not sent by the user.
+ *   - This checks the labelIds, which will contain the 'SENT' element if the
+ *     user sent the email message.
+ * @param emails
+ */
+function filterOutSentEmails (emails) {
+    return _.reject(emails, function (email) {
+        return _.contains(email.labelIds, 'SENT');
+    });
+}
+
+/**
+ * Processes a single email:
+ *   - adds the unread, emailDate, and emailMessage properties to the email
+ * @param email
+ * @returns {*}
+ */
+function processSingleEmail (email) {
+    // Return an object with just the following properties from the emails
+    return {
+        emailId: email.id,
+        from: parseHeaderProperty('From', email),
+        to: parseHeaderProperty('To', email),
+        unread: isEmailUnread(email),
+        internalDate: new Date(parseInt(email.internalDate)),
+        subject: parseHeaderProperty('Subject', email),
+        emailMessage: decodeBodyContents(email)
+    };
+}
+
+/**
+ * Processes a list of email messages by calling processSingleMessage on each
+ * @param emails {array[object]} email message
  * @returns {object} email
  */
-function preProcessEmails (email) {
-    // Add the unread, emailDate, and emailMessage properties
-    email.unread = isEmailUnread(email);
-    email.emailDate = new Date(parseInt(email.result.internalDate));
-    email.result.payload.emailMessage = decodeBodyContents(email);
-
-    return email;
+function processEmails (emails) {
+    return _.map(emails, processSingleEmail);
 }

--- a/js/gmail.message.js
+++ b/js/gmail.message.js
@@ -12,7 +12,7 @@ const EMPTY_BODY_DATA = {body: {data: ""}};
  * @returns {boolean}
  */
 this.isEmailUnread = function (email) {
-    return _.contains(email.result.labelIds, "UNREAD");
+    return _.contains(email.labelIds, 'UNREAD');
 };
 
 /**
@@ -56,6 +56,11 @@ function findPartWithGivenMime (parts, mime) {
     return EMPTY_BODY_DATA;
 }
 
+this.parseHeaderProperty = function (prop, email) {
+    var subject = _.findWhere(email.payload.headers, {name: prop});
+    return (subject && subject.value) || ''; // Return header value, or blank string if no such property
+};
+
 /**
  * Decodes the Base 64 encoded message body components and returns them.
  *  If HTML and Text are available, then both will be returned {object}.
@@ -65,9 +70,9 @@ function findPartWithGivenMime (parts, mime) {
  */
 this.decodeBodyContents = function (email) {
     try {
-        if (email.result.payload.parts && email.result.payload.parts.length) {
-            var htmlPart = findPartWithGivenMime(email.result.payload.parts, 'text/html'),
-                textPart = findPartWithGivenMime(email.result.payload.parts, 'text/plain');
+        if (email.payload.parts && email.payload.parts.length) {
+            var htmlPart = findPartWithGivenMime(email.payload.parts, 'text/html'),
+                textPart = findPartWithGivenMime(email.payload.parts, 'text/plain');
 
             return { // Only decode if there is actual data to decode
                 html: htmlPart.body.data ? B64.decode(htmlPart.body.data) : htmlPart.body.data,
@@ -75,7 +80,7 @@ this.decodeBodyContents = function (email) {
             };
         }
 
-        return B64.decode(email.result.payload.body.data);
+        return {html: B64.decode(email.payload.body.data)};
     } catch (e) {
         console.log('Email that caused the error:', email);
         throw e;

--- a/js/listeners.js
+++ b/js/listeners.js
@@ -11,7 +11,7 @@ const GMAIL_EMAIL_URL_REGEX = /(http|https):\/\/mail.google.com\/mail\/.*\/#inbo
  * @param url {String} URL
  * @returns {String} Email Message Id
  */
-const parseEmailId = function (url) {
+const parseThreadId = function (url) {
     var matches = url.match(GMAIL_EMAIL_ID_REGEX);
     return matches ? matches[0] : matches;
 };
@@ -29,7 +29,7 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
         tab.url.match(GMAIL_EMAIL_URL_REGEX)) {
 
         // Trigger the email analysis:
-        triggerEmailAnalysis(parseEmailId(tab.url));
+        triggerEmailAnalysis(parseThreadId(tab.url));
     }
 
     /*

--- a/js/secprototype.js
+++ b/js/secprototype.js
@@ -1,5 +1,4 @@
 /**
- * Created by Mike Rodrigues
  * Security Prototype Functionality
  */
 
@@ -19,16 +18,16 @@ authenticateExtension(switchAuthorizationStatus);
 /**
  * Function to start our email analysis
  *   Triggered from the listeners.js file by URL change (if a permitted URL)
- * @param emailId
+ * @param threadId
  */
-this.triggerEmailAnalysis = function (emailId) {
-    this.retrieveSingleEmail(emailId)
+this.triggerEmailAnalysis = function (threadId) {
+    retrieveEmailThread(threadId)
         .then(analyzeEmail);
 };
 
-function analyzeEmail (email) {
+function analyzeEmail (receivedEmailsInThread) {
     // TODO: Add email analysis algorithm here
-    console.log(email);
+    console.log(receivedEmailsInThread);
 
     var isPhishing = false;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
-  "name": "IA8660 - Gmail Chrome Extension PoC",
+  "name": "INSuRE - NEU Anti-Phishing Extension",
   "version": "1.0",
   "manifest_version": 2,
-  "description": "Mike's IA8660 Gmail Extension PoC",
+  "description": "INSuRE - Anti-Phishing Extension developed by the Phishing Research Team in Northeastern University's IA 8660 course.",
   // Used only for local development so OAuth works as if local version was installed from the store:
   "key": "<REPLACE_WITH_KEY_FROM_GOOGLE_CHROME_STORE>",
   "permissions": [


### PR DESCRIPTION
* Converted the code to retrieve the email thread since it was only retrieving the original email message.
* Removes sent emails from the thread since we are only scanning incoming email messages.
* Tweaked the email body parser response if only HTML is available.
* Limits the data that's returned per email to what is necessary to filter out properties that are unnecessary.
	* Added from, to, and subject properties - pulled from the headers
* Changed the extension name and description from Mike's PoC to "INSuRE - NEU Anti-Phishing Extension"

@anuragdwivedy - This is the PR to push my latest changes up on the repo.