### PR TITLE
Fixing listener trigger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,5 @@
 * Modified Safe browsing API check to only occur once per email thread to save calls and time.
 	* All links are aggregated and then checked by the API.
 	* We then have access to all threats, threat type, and the associated link in our analysis function.
+* Found a bug where the URL listener wasn't firing for emails with specific labels (eg. the Promotions label in Gmail).
+	* Identified that the Regex was not matching, so I updated the Regex so it will trigger for these URL formats as well.

--- a/js/background/listeners.js
+++ b/js/background/listeners.js
@@ -3,7 +3,7 @@
  * Event Listeners
  */
 
-const GMAIL_EMAIL_URL_REGEX = /(http|https):\/\/mail.google.com\/mail\/.*\/#inbox\/[1234567890abcdef]{16}/,
+const GMAIL_EMAIL_URL_REGEX = /(http|https):\/\/mail.google.com\/mail\/.*\/#.*\/[1234567890abcdef]{16}/,
     GMAIL_EMAIL_ID_REGEX = /[1234567890abcdef]{16}$/;
 
 /**


### PR DESCRIPTION
* Found a bug where the URL listener wasn't firing for emails with specific labels (eg. the Promotions label in Gmail).
	* Identified that the Regex was not matching, so I updated the Regex so it will trigger for these URL formats as well.