### PR TITLE
Adding keyword checking. Development blocked on Keywords + Pseudo code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,3 +122,11 @@
 	* Added temporary values, which will be updated as soon as correct keywords are obtained from Harshit.
 * Word frequency mapping is passed to our security prototype algorithm analysis function for final review.
 * Fixing bug where 'tel:' links were breaking Google Safe Browsing check
+
+## 11/15/2017 - Mike
+* Fixing a bug where plaintext message splitting would fail and then analysis would not occur.
+* Adding keyword mapping aggregation code for a single lookup table.
+* Adding code to check for keyword matches against the keyword list.
+	* Currently tallies the number of matches
+	* Also currently tallying the total number of words in all emails (in case the algorithm uses a ratio)
+* Development is now blocked until Roshan, Harshit, and/or Anurag send me the list of keywords and the algorithm pseudo code so that I can begin implementing those aspects.  Without the keywords or algorithm pseudo code, I cannot proceed with the development aspect as all other components have been implemented thusfar. 

--- a/js/background/gmail/fetch.js
+++ b/js/background/gmail/fetch.js
@@ -76,3 +76,28 @@ function processSingleEmail (email) {
 function processEmails (emails) {
     return _.map(emails, processSingleEmail);
 }
+
+/**
+ * Creates a single mapping of all words that occur in all emails to their frequencies
+ * @param params
+ */
+this.createKeywordMap = function (params) {
+    var emails = params.emails;
+
+    var keywords = _.pluck(emails, 'wordMap');
+    var totalNumWords = 0;
+
+    // Walk through all frequency mappings and tally the occurrences per word
+    params.keywordMap = _.reduce(keywords, function (keywordMapping, keywordMap) {
+        _.each(keywordMap, function (value, key) {
+            var currentVal = keywordMapping[key];
+            totalNumWords += value;
+            keywordMapping[key] = currentVal ? currentVal + value : value;
+        });
+
+        return keywordMapping;
+    }, {});
+    params.totalNumWords = totalNumWords;
+
+    return params;
+};

--- a/js/background/gmail/message.js
+++ b/js/background/gmail/message.js
@@ -82,7 +82,7 @@ this.parseHrefFromATag = function (aTag) {
  */
 this.createWordMapFromMessage = function (emailMessage) {
     const splitItem = /\s|\r|\n|\t/g; // space
-    var words = emailMessage && emailMessage.text.split(splitItem);
+    var words = emailMessage && emailMessage.text && emailMessage.text.split(splitItem);
 
     return _.countBy(words, function(word) {
         return word;

--- a/js/background/secprototype.js
+++ b/js/background/secprototype.js
@@ -24,6 +24,7 @@ this.triggerEmailAnalysis = function (threadId) {
     retrieveEmailThread(threadId)
         .then(fetchUserInterests)
         .then(fetchSafeBrowsingInformation)
+        .then(createKeywordMap)
         .then(analyzeEmail)
         .then(notifyUser);
 };
@@ -34,10 +35,21 @@ this.triggerEmailAnalysis = function (threadId) {
  * @returns {boolean}
  */
 function analyzeEmail (params) {
-    // TODO: Add email analysis algorithm here
     console.log(params);
 
     // TODO: currently our prototype will detect phishing if and only if Google's Safe Browsing API returns a threat
-    // return our algorithms result to pass to the displayHtmlStatus function
+
+    var numKeywordMatches = 0;
+    _.each(PHISHING_KEYWORDS, function (phishingKeyword) {
+        if (params.keywordMap[phishingKeyword]) {
+            numKeywordMatches++;
+        }
+    });
+
+    console.log('Number of keyword matches: ' + numKeywordMatches);
+
+    // return our algorithm's result in order to notify the user
+    //  false --> no phishing detected
+    //  true  --> phishing detected
     return params.linkThreats.length;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
       "js/background/safebrowsing/check.js",
       "js/background/secprototype.js",
       "js/background/database.js",
+      "js/background/keywords.js",
       "js/background/notifier.js"
     ]
   },


### PR DESCRIPTION
* Fixing a bug where plaintext message splitting would fail and then analysis would not occur.
* Adding keyword mapping aggregation code for a single lookup table.
* Adding code to check for keyword matches against the keyword list.
	* Currently tallies the number of matches
	* Also currently tallying the total number of words in all emails (in case the algorithm uses a ratio)
* **Development is now blocked until Roshan (@roshanpty), Harshit, and/or Anurag (@anuragdwivedy) send me the list of keywords and the algorithm pseudo code so that I can begin implementing those aspects.  Without the keywords or algorithm pseudo code, I cannot proceed with the development aspect as all other components have been implemented thusfar.**